### PR TITLE
chore: update readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,23 +1,33 @@
-The AGNTCY (pronounced “agency”) project is the collective of contributors and maintainers building the Internet of Agents (IoA): an open, interoperable, internet for agent-to-agent collaboration. AGNTCY is proudly part of the [Linux Foundation](https://www.linuxfoundation.org/)
+# AGNTCY
 
-- [Governance](https://github.com/agntcy/governance)
-- [Contributions](https://github.com/agntcy/governance/blob/main/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/agntcy/governance/blob/main/CODE_OF_CONDUCT.md)
+The AGNTCY project is the collective of contributors and maintainers building the Internet of Agents (IoA): an open, interoperable, internet for agent-to-agent collaboration. AGNTCY is proudly part of the [Linux Foundation](https://www.linuxfoundation.org/).
+
+The AGNTCY platform is an open source framework designed to enable standardized discovery, orchestration, and collaboration between AI agents across different frameworks and platforms (LangGraph, LlamaIndex, CrewAI, etc.) through standardized protocols.
+
+## Getting Started
+
+For getting started on AGNTCY look at [CoffeeAgntcy](https://github.com/agntcy/coffeeAgntcy) which is a reference implementation based on a fictitious coffee company to help developers understand how components in the AGNTCY Internet of Agents ecosystem can work together. It gives examples of the components of AGNTCY working together as a Multi-agent System (MAS).
+
+For more information, see the [AGNTCY documentation](https://docs.agntcy.org/), where you can find component-level getting started guides, such as [SLIM](https://docs.agntcy.org/messaging/slim-howto/), [Identity](https://docs.agntcy.org/how-to-guides/identity-quickstart/), and Agent [Directory](https://docs.agntcy.org/how-to-guides/agent-directory/).
+
+Love our mission and work? If you decide to contribute to any of our sub-projects, we would be delighted to collaborate with you. Here are some options:
+
+* Pick up a ["good first issue"](https://github.com/search?q=org%3Aagntcy+type%3Aissue+label%3A%22good-first-issue%22&type=issues)
+* Create issues across our repositories (bugs, enhancements, or feature ideas).
+* Review a PR.
+
+Check out the AGNTCY [Contributing Guide](https://github.com/agntcy/governance/blob/main/CONTRIBUTING.md), our [Governance](https://github.com/agntcy/governance) repository, and our [Code of Conduct](https://github.com/agntcy/governance/blob/main/CODE_OF_CONDUCT.md). Visit [agntcy.org](https://agntcy.org) to learn more!
+
+## Connect with Us
+
+* [Slack](https://agntcy.slack.com/ssb/redirect) 
+* [AGNTCY Slack self join link](https://join.slack.com/t/agntcy/shared_invite/zt-34sxmw5e8-LqlUxxcxROq3HRb56QSkUg)
+* [YouTube](https://www.youtube.com/playlist?list=PL49BrgsjXg5rUr_jw8VHLaz-roTuRRIjG) 
+* [LinkedIn](https://www.linkedin.com/company/agntcyproject/posts/?feedView=all) 
+* [Working Groups](https://github.com/agntcy/governance/tree/main/working-groups)
+* [AGNTCY Meeting Calendar](https://calendar.google.com/calendar/u/0/embed?src=admin@ops.agntcy.org)
 
 
-Visit [agntcy.org](https://agntcy.org) to learn more!
+### Technical Steering Committee
 
-* * * * *
-
-[Working Groups](https://github.com/agntcy/governance/blob/main/working-groups/WORKING-GROUPS.md)
-
-AGNTCY working groups are organizations responsible for the design and implementation of large architectural aspects of the overall AGNTCY project. Working groups operate with a fair amount of autonomy within the broader scope of the project. The Technical Steering Committee approves the creation of new working groups.
-
-The AGNTCY project welcomes those interested to join discussions in Slack, attend meetings, review roadmap items, comment on issues/PRs, and any other contribution methods!
-
-* * * * *
-
-- Agntcy GitHub Docs [https://github.com/agntcy/docs](https://github.com/agntcy/docs)
-- Published documentation [docs.agntcy.org](https://docs.agntcy.org)
-
-* * * * *
+Current TSC members can be found [here](https://github.com/agntcy/governance/blob/main/CONTRIBUTING.md#technical-steering-committee-members).


### PR DESCRIPTION
Fixes #7 

Updates the readme with the same content as in the .github-private repo.